### PR TITLE
Fix time step printing in Matlab console

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Bug description**
+A clear and concise description of the bug.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Compile with '...'
+2. Run '...' case with '...' settings
+3. Open '...' output
+4. See the error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**OpenFAST Version**
+Please provide as much detail as possible including git commit. The best information is a screenshot of the OpenFAST system description that prints when running OpenFAST:
+```
+**************************************************************************************************
+ OpenFAST
+
+ Copyright (C)  National Renewable Energy Laboratory
+ Copyright (C)  Envision Energy USA LTD
+
+ This program is licensed under Apache License Version 2.0 and comes with ABSOLUTELY NO WARRANTY.
+ See the "LICENSE" file distributed with this software for details.
+ **************************************************************************************************
+
+ OpenFAST-v2.0.0
+ Compile Info:
+  - Architecture: 64 bit
+  - Precision: double
+  - Date: Nov 27 2018
+  - Time: 17:19:38
+ Execution Info:
+  - Date: 11/29/2018
+  - Time: 10:52:28-0700
+```
+
+**System Information (please complete the following information):**
+ - OS: [e.g. Ubuntu 14.04 or macOS 10.12]
+ - Compiler: [e.g. GFortran 4.4]
+ - Compiler settings: [e.g. CMake flags or other settings]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,38 +11,37 @@ os:
     - linux
     - osx
 
-# linux configuration; container-based environments (default for linux) require the following setup block
-addons:
-  apt:
-    packages:
-      - gfortran
-      - libblas-dev
-      - liblapack-dev
-
 env:
     - FC=/usr/local/bin/gfortran-7; DOUBLE_PRECISION=ON
     - FC=/usr/local/bin/gfortran-7; DOUBLE_PRECISION=OFF
     - FC=/usr/bin/gfortran; DOUBLE_PRECISION=ON
     - FC=/usr/bin/gfortran; DOUBLE_PRECISION=OFF
+    - FC=ifort; DOUBLE_PRECISION=ON; TRAVIS_BUILD_INTEL=YES
 
-# mac configuration
 before_install:
-    # first uninstall a conflicting package
-#    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
-
-    # install required packages
+    # mac configuration
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade python; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc@7; fi
-    # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cmake; fi  # cmake is already installed in the default mac image
+
+    # linux configuration
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install gfortran; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libblas-dev liblapack-dev; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pyenv shell 3.6.3; fi
+
+    # intel compiler
+    # this build requires setting an environment variable https://docs.travis-ci.com/user/environment-variables#defining-encrypted-variables-in-travisyml
+    # INTEL_SERIAL_NUMBER=XXXX-XXXXXXXX
+    - if [[ -n "${TRAVIS_BUILD_INTEL}" ]] ; then wget 'https://raw.githubusercontent.com/nemequ/icc-travis/master/install-icc.sh'; fi
+    - if [[ -n "${TRAVIS_BUILD_INTEL}" ]] ; then chmod 755 install-icc.sh; fi
+    - if [[ -n "${TRAVIS_BUILD_INTEL}" ]] ; then ./install-icc.sh --components ifort,icc,mkl; source ~/.bashrc; fi
 
     # common configuration
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pyenv shell 3.6.3; fi
     - pip3 install numpy
 
 install:
     - mkdir build && cd build
-    - cmake .. -DBUILD_TESTING=ON -DDOUBLE_PRECISION=$DOUBLE_PRECISION
+    - cmake .. -DBUILD_TESTING=ON -DDOUBLE_PRECISION=$DOUBLE_PRECISION -DBUILD_SHARED_LIBS=ON
     - make -j 8 install
 
 matrix:
@@ -55,13 +54,15 @@ matrix:
       env: FC=/usr/bin/gfortran; DOUBLE_PRECISION=ON
     - os: osx
       env: FC=/usr/bin/gfortran; DOUBLE_PRECISION=OFF
+    - os: osx
+      env: FC=ifort; DOUBLE_PRECISION=ON; TRAVIS_BUILD_INTEL=YES
 
 script:
     # beamdyn unit tests
-    - if [[ "$DOUBLE_PRECISION" == "ON" ]]; then ctest -R beamdyn_utest; fi
+    - if [[ "$DOUBLE_PRECISION" == "ON" ]]; then ctest -VV -R beamdyn_utest; fi
 
     # beamdyn regression tests
-    - if [[ "$DOUBLE_PRECISION" == "ON" ]]; then ctest -R bd_; fi
+    - if [[ "$DOUBLE_PRECISION" == "ON" ]]; then ctest -VV -R bd_; fi
 
     # subset of openfast regression tests
     # do not run

--- a/glue-codes/simulink/src/create_FAST_SFunc.m
+++ b/glue-codes/simulink/src/create_FAST_SFunc.m
@@ -6,35 +6,34 @@ mexname = 'FAST_SFunc';
 switch computer('arch')
     case 'win64'
         % this is set up for files generated using the x64 configuration of vs-build
-        binDir = '../../../build/bin';
-        libname = 'OpenFAST-Simulink_x64';
-        outDir = binDir;
+        libDir = '../../../build/bin';
+        includeDir = '/usr/local/include';
+        libName = 'OpenFAST-Simulink_Win32';
+        outDir = libDir;
         
     case 'win32'
         % this is set up for files generated using the x86 configuration of vs-build
-        binDir = '../../../build/bin';
-        libname = 'OpenFAST-Simulink_Win32';
-        outDir = binDir;
+        libDir = '../../../build/bin';
+        includeDir = '/usr/local/include';
+        libName = 'OpenFAST-Simulink_Win32';
+        outDir = libDir;
         
     case 'maci64'
-        binDir = '/usr/local/lib';
-        libname = 'openfastlib';
+        libDir = '/usr/local/lib';
+        includeDir = '/usr/local/include';
+        libName = 'openfastlib';
         outDir = '.';
-        
-%         mex -L/usr/local/lib -lopenfastlib ...    
-%             -I/usr/local/include -outdir . COMPFLAGS='$COMPFLAGS -MT' FAST_SFunc.c 
-            % This builds the mex file in the current directory, ./openfast/glue-codes/simulink/src/
+
     otherwise
         error('Unexpected computer architecture type.')
 end
 
-    mex( '-largeArrayDims', ['-L' binDir], ['-l' libname] ,...
-        '-I../../../modules-local/openfast-library/src', '-I../../../build/types-files', ['-I' binDir], '-outdir', outDir, ...
-        ['COMPFLAGS=$COMPFLAGS /MT /D S_FUNCTION_NAME=' mexname], '-output', mexname, ...
-        'FAST_SFunc.c');
-
-
-%%
- %addpath('C:\Users\bjonkman\Documents\CAETools\FASTv8\bin');
- %addpath('C:\Users\bjonkman\Documents\CAETools\FASTv8\Simulink\Samples');
-% use mex -setup to configure a C compiler
+mex('-largeArrayDims', ...
+    ['-L' libDir], ...
+    ['-l' libName], ...
+    ['-I' includeDir], ...
+    '-outdir', outDir, ...
+    'COMPFLAGS=$COMPFLAGS -MT -D', ...
+    ['S_FUNCTION_NAME=' mexname], ...
+    '-output', mexname, ...
+    'FAST_SFunc.c');

--- a/modules-local/aerodyn14/src/DWM_driver_wind_farm.f90
+++ b/modules-local/aerodyn14/src/DWM_driver_wind_farm.f90
@@ -3,7 +3,7 @@ PROGRAM DWM_driver_wind_farm
    USE DWM_driver_wind_farm_sub
    USE read_wind_farm_parameter_data, ONLY: NumWT, DWM_exe_name
    USE DWM_init_data, ONLY:InputFile
-#ifdef _WIN32
+#ifdef __INTEL_COMPILER
    USE IFPORT
 #endif
    

--- a/modules-local/aerodyn14/src/DWM_driver_wind_farm_sub.f90
+++ b/modules-local/aerodyn14/src/DWM_driver_wind_farm_sub.f90
@@ -838,9 +838,8 @@ SUBROUTINE rename_FAST_output(SimulationOrder_index)
 !............................................................................
 ! This routine is called to rename the fast output
 !............................................................................
-#ifdef _WIN32
+#ifdef __INTEL_COMPILER
     USE IFPORT
-    USE DFLIB
 #endif
     USE wind_farm_geometry_data,         ONLY: turbine_sort
     USE DWM_init_data,                   ONLY: OutFileRoot

--- a/modules-local/beamdyn/src/BeamDyn.f90
+++ b/modules-local/beamdyn/src/BeamDyn.f90
@@ -1392,6 +1392,7 @@ subroutine Init_MiscVars( p, u, y, m, ErrStat, ErrMsg )
       CALL AllocAry(m%LP_StifK_LU,  p%dof_total-6,p%dof_total-6,                                'LP_StifK_LU', ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       CALL AllocAry(m%LP_StifK,     p%dof_total,p%dof_total,                                    'LP_StifK',    ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       CALL AllocAry(m%LP_MassM,     p%dof_total,p%dof_total,                                    'LP_MassM',    ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      CALL AllocAry(m%LP_MassM_LU,  p%dof_total-6,p%dof_total-6,                                'LP_MassM_LU', ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       CALL AllocAry(m%LP_indx,      p%dof_total,                                                'LP_indx',     ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
          !  LAPACK routine outputs converted to dimensionality used in BD.  Note the index ordering here is due to reshape functions before calls to LAPACK routines

--- a/modules-local/hydrodyn/src/HydroDyn.f90
+++ b/modules-local/hydrodyn/src/HydroDyn.f90
@@ -1282,17 +1282,15 @@ SUBROUTINE HydroDyn_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, I
       IF(ALLOCATED( Waves_InitOut%WaveElevC0 ))  DEALLOCATE( Waves_InitOut%WaveElevC0 )
       !IF(ALLOCATED( InitLocal%WAMIT%WaveElevC0 ))  DEALLOCATE( InitLocal%WAMIT%WaveElevC0)
       
-         
-      
          ! Close the summary file
-         
-      CALL HDOut_CloseSum( InitLocal%UnSum, ErrStat2, ErrMsg2 )
-         CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-         IF ( ErrStat >= AbortErrLev ) THEN
-            CALL CleanUp()
-            RETURN
-         END IF
-    
+      IF ( InitLocal%HDSum ) THEN
+         CALL HDOut_CloseSum( InitLocal%UnSum, ErrStat2, ErrMsg2 )
+            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
+            IF ( ErrStat >= AbortErrLev ) THEN
+               CALL CleanUp()
+               RETURN
+            END IF
+      END IF
       
       ! Define system output initializations (set up mesh) here:
       

--- a/modules-local/nwtc-library/src/NWTC_IO.f90
+++ b/modules-local/nwtc-library/src/NWTC_IO.f90
@@ -1801,8 +1801,6 @@ CONTAINS
 
       IF ( ( Str(IC:IC) >= 'a' ).AND.( Str(IC:IC) <= 'z' ) )  THEN
          Str(IC:IC) = CHAR( ICHAR( Str(IC:IC) ) - 32 )
-      ELSE
-         Str(IC:IC) = Str(IC:IC)
       END IF
 
    END DO ! IC

--- a/modules-local/nwtc-library/src/SysMatlabLinuxIntel.f90
+++ b/modules-local/nwtc-library/src/SysMatlabLinuxIntel.f90
@@ -378,7 +378,7 @@ SUBROUTINE WriteScr ( Str, Frm )
    END IF
 
    Str2 = trim(Str2)//NewLine
-   Stat = mexPrintf( Str2 )
+   Stat = mexPrintF( Str2 )
 
 END SUBROUTINE WriteScr ! ( Str )
 !=======================================================================

--- a/modules-local/openfast-library/src/FAST_Subs.f90
+++ b/modules-local/openfast-library/src/FAST_Subs.f90
@@ -4641,11 +4641,7 @@ SUBROUTINE FAST_Solution(t_initial, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, 
       
    IF (p_FAST%WrSttsTime) then
       IF ( MOD( n_t_global + 1, p_FAST%n_SttsTime ) == 0 ) THEN
-      
-         if (.not. Cmpl4SFun) then   
-            CALL SimStatus( m_FAST%TiLstPrn, m_FAST%PrevClockTime, m_FAST%t_global, p_FAST%TMax, p_FAST%TDesc )
-         end if
-      
+         CALL SimStatus( m_FAST%TiLstPrn, m_FAST%PrevClockTime, m_FAST%t_global, p_FAST%TMax, p_FAST%TDesc )      
       ENDIF
    ENDIF
      

--- a/modules-local/openfast-registry/src/misc.c
+++ b/modules-local/openfast-registry/src/misc.c
@@ -5,6 +5,8 @@
 #ifdef _WIN32
 # define rindex(X,Y) strrchr(X,Y)
 # define index(X,Y) strchr(X,Y)
+# include <process.h>
+# define getpid _getpid
 #else
 # include <strings.h>
 # include <sys/types.h>

--- a/modules-local/openfast-registry/src/registry.c
+++ b/modules-local/openfast-registry/src/registry.c
@@ -5,6 +5,8 @@
 # include <io.h>
 # define rindex(X,Y) strrchr(X,Y)
 # define index(X,Y) strchr(X,Y)
+# include <process.h>
+# define getpid _getpid
 #else
 # include <sys/time.h>
 # include <sys/resource.h>


### PR DESCRIPTION
Hi @bjonkman 

I worked with @nikhar-abbas to verify that your simulink updates work on Mac. Everything looks to work well, but I made a couple of changes.

First, I cleaned up SFunc creation routine a little more. Looking at this again now, I see why you named things the way you did, but I renamed some variables based on the nomenclature on Mac/linux. Specifically, the directory to link with `-L` is `.../lib` on Mac, so I called it `libDir`. I also just realized we need to update the `includeDir` with the default location on Windows. In any case, my point with mentioning this is that if you don't agree with the changes in `create_FAST_SFunc.m`, I'm not tied to any of it so I can revert it.

The change that I do feel strongly about is in calling `SimStatus` from FAST_Subs when running with simulink. I found that this call was wrapped in
```
         if (.not. Cmpl4SFun) then   		
            CALL SimStatus( m_FAST%TiLstPrn, m_FAST%PrevClockTime, m_FAST%t_global, p_FAST%TMax, p_FAST%TDesc )		
         end if
```
so none of the time step printouts would show in the Matlab console.

Also, this pull request includes a merge from `openfast/dev` which brings in the fix in building the dwm driver.

Thanks
Rafael