### PR TITLE
Airfoil-interp PR: Update r-test for new baseline

### DIFF
--- a/modules/aerodyn/src/AirfoilInfo.f90
+++ b/modules/aerodyn/src/AirfoilInfo.f90
@@ -429,9 +429,6 @@ MODULE AirfoilInfo
       
       ! Default to linear interpolation
    DefaultInterpOrd = 1      
-#ifdef SPLINE_INTERP
-   DefaultInterpOrd = 3      
-#endif
       
       CALL ParseVarWDefault ( FileInfo, CurLine, 'InterpOrd', p%InterpOrd, DefaultInterpOrd, ErrStat2, ErrMsg2, UnEc )
          CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )


### PR DESCRIPTION
Also removed precompilier directive `SPLINE_INTERP` from AirfoilInfo now that we are satisfied with r-test baseline results using linear interp of airfoils in AD15.